### PR TITLE
Add relative path support to 'folders add' command

### DIFF
--- a/cmd_repositories.go
+++ b/cmd_repositories.go
@@ -118,9 +118,7 @@ func foldersList(c *cli.Context) {
 func foldersAdd(c *cli.Context) {
 	cfg := getConfig(c)
 	abs, err := filepath.Abs(c.Args()[1])
-	if err != nil {
-		die(err)
-	}
+	die(err)
 	folder := config.FolderConfiguration{
 		ID:   c.Args()[0],
 		Path: filepath.Clean(abs),


### PR DESCRIPTION
Previously command like

```
syncthing-cli folders add folder_id .
```

would create repository with path `.`
Now it will be converted into correct absolute path to current folder.
