### PR TITLE
'-' is a legal hostname character, just not at the beginning.

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -146,7 +146,7 @@ func validAddress(input string) {
 	if len(tokens) != 2 {
 		die(input + " is not a valid value for an address\nExpected format <ip or hostname>:<port>")
 	}
-	matched, err := regexp.MatchString("^[a-zA-Z0-9]+([a-zA-Z0-9.]+[a-zA-Z0-9]+)?$", tokens[0])
+	matched, err := regexp.MatchString("^[a-zA-Z0-9]+([-a-zA-Z0-9.]+[-a-zA-Z0-9]+)?$", tokens[0])
 	die(err)
 	if !matched {
 		die(input + " is not a valid value for an address\nExpected format <ip or hostname>:<port>")


### PR DESCRIPTION
syncthing-cli rejects hostnames with a '-' character in them.  This is actually legal, so long as it isn't at the start.